### PR TITLE
cmake: Ensure that executables and shared libraries are PIE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,15 @@ include("cmake/utils.cmake")
 
 project("BTFParse")
 
+# Needed to be able to check if the compiler supports linking with PIE,
+# otherwise the resulting executable or shared library won't be PIE.
+include(CheckPIESupported)
+check_pie_supported()
+
+if(NOT CMAKE_C_LINK_PIE_SUPPORTED OR NOT CMAKE_CXX_LINK_PIE_SUPPORTED)
+    message(FATAL_ERROR "The current compiler does not support -fPIE or -pie")
+endif()
+
 if(BTFPARSE_ENABLE_TESTS)
   include(CTest)
   enable_testing()


### PR DESCRIPTION
If we don't check the support for PIE flags with check_pie_supported,
cmake won't generate a linker CLI with the PIE flags,
so the resulting binaries won't be PIE.